### PR TITLE
Fix missing return value in ProxyDialogPyQt.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -238,7 +238,7 @@ class ShellEngine(Engine):
                         # the trick of activating + raising does not seem to be enough for
                         # modal dialogs. So force put them on top as well.                        
                         self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint | self.windowFlags())
-                        QtGui.QDialog.exec_(self)
+                        return QtGui.QDialog.exec_(self)
                 
                 
                 # hot patch the library to make it work with pyside code


### PR DESCRIPTION
Return the appropriate DialogCode from the exec_ method of
ProxyDialogPyQt.