### PR TITLE
Allows on-the-fly context changes.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -77,6 +77,16 @@ class ShellEngine(Engine):
         return self._ui_created
 
     ##########################################################################################
+    # properties
+
+    @property
+    def context_change_allowed(self):
+        """
+        Allows on-the-fly context changing.
+        """
+        return True
+
+    ##########################################################################################
     # command handling
 
     def execute_command(self, cmd_key, args):


### PR DESCRIPTION
Prior to this, context changing didn't work at all in tk-shell. My expectation was that it would, but would be slower due to the requirement that the engine be shutdown and restarted. However, even when that occurred, the engine instance available in the shell wouldn't reflect the new context. That is resolved by allowing the context change to occur on the fly without an engine restart.