### PR TITLE
38534 qapplication error

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -127,23 +127,28 @@ class ShellEngine(Engine):
             tk_shell = self.import_module("tk_shell")
             t = tk_shell.Task(self, cb, args)
             
-            # start up our QApp now
-            qt_application = QtGui.QApplication([])
-            qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))
-            self._initialize_dark_look_and_feel()
-            
-            # when the QApp starts, initialize our task code 
-            QtCore.QTimer.singleShot(0, t.run_command )
-               
-            # and ask the main app to exit when the task emits its finished signal
-            t.finished.connect(qt_application.quit )
-               
-            # start the application loop. This will block the process until the task
-            # has completed - this is either triggered by a main window closing or
-            # byt the finished signal being called from the task class above.
-            qt_application.exec_()
-            
+            # start up our QApp now, if none is already running
+            qt_application = None
+            if not QtGui.qApp:
+                qt_application = QtGui.QApplication([])
+                qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))
+                self._initialize_dark_look_and_feel()
 
+            # if we didn't start the QApplication here, let the responsability
+            # to run the exec loop and quit to the initial creator of the QApplication
+            if qt_application:
+                # when the QApp starts, initialize our task code
+                QtCore.QTimer.singleShot(0, t.run_command )
+                # and ask the main app to exit when the task emits its finished signal
+                t.finished.connect(qt_application.quit)
+
+                # start the application loop. This will block the process until the task
+                # has completed - this is either triggered by a main window closing or
+                # byt the finished signal being called from the task class above.
+                qt_application.exec_()
+            else:
+                # we can run the command now, as the QApp is already started
+                t.run_command()
 
     ##########################################################################################
     # logging interfaces


### PR DESCRIPTION
These changes allow to call `engine.execute_command` from an App running in tk-shell.
- A QApplication is created only if none is available.
- If a QApplication is already running, it is assumed an `exec` loop is already running.
- The callback is called straightaway, as the QApp is already running. If instead the `QTimer.singleShot` is used instead, the callback is never called, may be because the queued task is garbaged collected?
- The implementation assumes that the first command being run acts as a "parent" of all the other ones, so when it exits, the whole App exits. I'm not sure this is right, but couldn't come up with a better behaviour... Up for discussion!
