### PR TITLE
Fix bug arising from PyQt4 where QtGui.qApp is not initialized to None

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -65,7 +65,7 @@ class ShellEngine(Engine):
         # a QApplication has been created.
         if self._has_qt:
             from tank.platform.qt import QtGui
-            return QtGui.qApp is not None
+            return QtGui.QApplication.instance() is not None
         else:
             return False
 
@@ -129,7 +129,7 @@ class ShellEngine(Engine):
             
             # start up our QApp now, if none is already running
             qt_application = None
-            if not QtGui.qApp:
+            if not QtGui.QApplication.instance():
                 qt_application = QtGui.QApplication([])
                 qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))
                 self._initialize_dark_look_and_feel()


### PR DESCRIPTION
For example, in this first case we have what looks like a QApplication
object, but it is not really there and will cause problems later.

$ python -c 'from PyQt4 import QtGui; print QtGui.qApp'
<PyQt4.QtGui.QApplication object at 0x7f2f884776b0>

$ python -c 'from PySide import QtGui; print QtGui.qApp'
None

Instead we can use QtGui.QApplication.instance(), which always works and
is documented in PySide to return the same as QtGui.qApp anyway.