### PR TITLE
SMOK-44691 | Avoid system QT to ensure compatibility

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -130,6 +130,7 @@ class ShellEngine(Engine):
             # start up our QApp now, if none is already running
             qt_application = None
             if not QtGui.qApp:
+                QtGui.QApplication.setLibraryPaths([])
                 qt_application = QtGui.QApplication([])
                 qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))
                 self._initialize_dark_look_and_feel()


### PR DESCRIPTION
This removes the system Qt library paths before the initialization of the UI, otherwise, we might have an error when starting something from tank from a system having an incompatible Qt version.

![launch_tank](https://cloud.githubusercontent.com/assets/6785406/26464353/806d40c0-4155-11e7-9f6c-04e7845807d9.png)


