### PR TITLE
For #44051, ShellEngine.host_info

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -182,14 +182,12 @@ class ShellEngine(Engine):
         """
         Returns information about the application hosting this engine.
         
-        Returns information about the Python interpreter.
-
-        :returns: A (name, release) tuple.
+        :returns: A {"name": "Python", "version": Python version} dictionary.
         """
-        return (
-            "Python",
-            platform.python_version(),
-        )
+        return {
+            "name": "Python",
+            "version": platform.python_version(),
+        }
 
     ##########################################################################################
     # pyside / qt

--- a/engine.py
+++ b/engine.py
@@ -184,13 +184,9 @@ class ShellEngine(Engine):
         
         Returns information about the Python interpreter.
 
-        :returns: A :class:`tank.platform.HostInfo` instance.
+        :returns: A (name, release) tuple.
         """
-        # We defer importing HostInfo to the point where tk-core will call this
-        # method, so we don't cause problems with earlier tk-core releases which
-        # don't support it yet.
-        from tank.platform import HostInfo
-        return HostInfo(
+        return (
             "Python",
             platform.python_version(),
         )

--- a/engine.py
+++ b/engine.py
@@ -18,6 +18,7 @@ import inspect
 import logging
 import sys
 import os
+import platform
 
 from tank.platform import Engine
 from tank import TankError
@@ -172,6 +173,27 @@ class ShellEngine(Engine):
     
     def log_error(self, msg):
         self._log.error(msg)
+
+    ##########################################################################################
+    # metrics
+
+    @property
+    def host_info(self):
+        """
+        Returns information about the application hosting this engine.
+        
+        Returns information about the Python interpreter.
+
+        :returns: A :class:`tank.platform.HostInfo` instance.
+        """
+        # We defer importing HostInfo to the point where tk-core will call this
+        # method, so we don't cause problems with earlier tk-core releases which
+        # don't support it yet.
+        from tank.platform import HostInfo
+        return HostInfo(
+            "Python",
+            platform.python_version(),
+        )
 
     ##########################################################################################
     # pyside / qt


### PR DESCRIPTION
Implemented Engine.host_info method needed by new tk-core metrics: returns informations about the Python interpreter.