### PR TITLE
SG-14205: investigate fake positive build

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -63,14 +63,13 @@ class ShellEngine(Engine):
         Init
         """
 
-    def destroy(self):
+    def destroy_engine(self):
         """
         Called when engine is destroyed.
 
         This will remove the logger.
         """
         self._cleanup_logger()
-        super(ShellEngine, self).destroy()
 
     def __del__(self):
         """

--- a/engine.py
+++ b/engine.py
@@ -73,15 +73,16 @@ class ShellEngine(Engine):
 
     def __del__(self):
         """
+        Called when the object is garbaged-collected.
         """
-        # If the engine is not properly finalized, still remove the stream logger
-        # if available. This is important during testing, which the logger can be
-        # installed and uninstalled multiple times.
+        # If the destroy_engine has not been called (in a failed test for example), we still
+        # need to remove the stream logger if available. Otherwise subsequent tests will
+        # have more and more loggers added to tank.tk-shell.
         self._cleanup_logger()
 
     def _cleanup_logger(self):
         """
-        Removes the stream handler if it exists.
+        Removes the stream handler if it exists from the current logger.
         """
         if self._stream_handler is not None:
             self._log.removeHandler(self._stream_handler)

--- a/engine.py
+++ b/engine.py
@@ -48,7 +48,6 @@ class ShellEngine(Engine):
         # If no log was found, we'll install our own handler so things
         # get printed to the console.
         if self._log is None:
-            # set up a very basic logger, assuming it will be overridden
             self._log = logging.getLogger("tank.tk-shell")
             self._log.setLevel(logging.INFO)
             self._stream_handler = logging.StreamHandler()


### PR DESCRIPTION
While investigating a weird exception raised multiple times in the publish unit tests, I discovered that actually the exception was raised only once but printed multiple times because each test that ran started the `tk-shell` engine and each added a logger to the `tank.tk-shell` logger. By the end when the test would run, it would look as if the test raised the error over 20+ times. It was actually raised once and after looking at the test, it was actually expected.