### PR TITLE
SG-15481 fixed PySide2 linux error

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -182,7 +182,7 @@ class ShellEngine(Engine):
                 if (
                     tank.util.is_linux()
                     and os.environ.get("KDE_FULL_SESSION") is not None
-                    and QtCore.qVersion()[0] == 4
+                    and QtCore.qVersion()[0] == "4"
                 ):
 
                     QtGui.QApplication.setLibraryPaths([])

--- a/engine.py
+++ b/engine.py
@@ -169,6 +169,7 @@ class ShellEngine(Engine):
             # We are using the QtImporter rather than the sgtk.platform.qt so that we
             # can check the Qt version further down.
             from sgtk.util.qt_importer import QtImporter
+
             importer = QtImporter()
             QtCore = importer.QtCore
             QtGui = importer.QtGui

--- a/engine.py
+++ b/engine.py
@@ -186,7 +186,7 @@ class ShellEngine(Engine):
                 if (
                     tank.util.is_linux()
                     and os.environ.get("KDE_FULL_SESSION") is not None
-                    and importer.qt_version_tuple[0] == 4:
+                    and importer.qt_version_tuple[0] == 4
                 ):
 
                     QtGui.QApplication.setLibraryPaths([])

--- a/engine.py
+++ b/engine.py
@@ -166,13 +166,7 @@ class ShellEngine(Engine):
             # QT not available - just run the command straight
             return cb(*args)
         else:
-            # We are using the QtImporter rather than the sgtk.platform.qt so that we
-            # can check the Qt version further down.
-            from sgtk.util.qt_importer import QtImporter
-
-            importer = QtImporter()
-            QtCore = importer.QtCore
-            QtGui = importer.QtGui
+            from sgtk.platform.qt import QtCore, QtGui
 
             # we got QT capabilities. Start a QT app and fire the command into the app
             tk_shell = self.import_module("tk_shell")
@@ -184,10 +178,11 @@ class ShellEngine(Engine):
                 # We need to clear Qt library paths on Linux if KDE is the active environment.
                 # This resolves issues with mismatched Qt libraries between the OS and the
                 # application being launched if it is a DCC that comes with a bundled Qt.
+                # It appears to only need to be fixed in PySide (1), PySide2 is fine.
                 if (
                     tank.util.is_linux()
                     and os.environ.get("KDE_FULL_SESSION") is not None
-                    and importer.qt_version_tuple[0] == 4
+                    and QtCore.__version_info__[0] == 4
                 ):
 
                     QtGui.QApplication.setLibraryPaths([])

--- a/engine.py
+++ b/engine.py
@@ -166,7 +166,12 @@ class ShellEngine(Engine):
             # QT not available - just run the command straight
             return cb(*args)
         else:
-            from tank.platform.qt import QtCore, QtGui
+            # We are using the QtImporter rather than the sgtk.platform.qt so that we
+            # can check the Qt version further down.
+            from sgtk.util.qt_importer import QtImporter
+            importer = QtImporter()
+            QtCore = importer.QtCore
+            QtGui = importer.QtGui
 
             # we got QT capabilities. Start a QT app and fire the command into the app
             tk_shell = self.import_module("tk_shell")
@@ -181,14 +186,16 @@ class ShellEngine(Engine):
                 if (
                     tank.util.is_linux()
                     and os.environ.get("KDE_FULL_SESSION") is not None
+                    and importer.qt_version_tuple[0] == 4:
                 ):
+
                     QtGui.QApplication.setLibraryPaths([])
 
                 qt_application = QtGui.QApplication([])
                 qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))
                 self._initialize_dark_look_and_feel()
 
-            # if we didn't start the QApplication here, let the responsability
+            # if we didn't start the QApplication here, leave the responsibility
             # to run the exec loop and quit to the initial creator of the QApplication
             if qt_application:
                 # when the QApp starts, initialize our task code

--- a/engine.py
+++ b/engine.py
@@ -182,7 +182,7 @@ class ShellEngine(Engine):
                 if (
                     tank.util.is_linux()
                     and os.environ.get("KDE_FULL_SESSION") is not None
-                    and QtCore.__version_info__[0] == 4
+                    and QtCore.qVersion()[0] == 4
                 ):
 
                     QtGui.QApplication.setLibraryPaths([])


### PR DESCRIPTION
There was a fix previously introduced to allow PySide (1) to work on Linux in KDE.
However this fix which provided an empty list to the `QtGui.QApplication.setLibraryPaths([])` broke PySide2.

This fix means that the old fix is only applied in PySide (1)