### PR TITLE
SG-3081 - Add High-DPI support to the FPTR desktop app and tank

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -188,7 +188,9 @@ class ShellEngine(Engine):
                     elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
                         pass
                     else:
-                        QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+                        QtCore.QCoreApplication.setAttribute(
+                            QtCore.Qt.AA_EnableHighDpiScaling
+                        )
 
                 qt_application = QtGui.QApplication([])
                 qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))

--- a/engine.py
+++ b/engine.py
@@ -175,9 +175,20 @@ class ShellEngine(Engine):
             # start up our QApp now, if none is already running
             qt_application = None
             if not QtGui.QApplication.instance():
-                # Enable High DPI support in Qt5 (default enabled in Qt6)
                 if QtCore.qVersion()[0] == "5":
-                    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+                    # Enable High DPI support in Qt5 (default enabled in Qt6)
+                    #
+                    # Only enable it if none of the Qt environment variables related to
+                    # High-DPI are set
+
+                    if "QT_AUTO_SCREEN_SCALE_FACTOR" in os.environ:
+                        pass
+                    elif "QT_SCALE_FACTOR" in os.environ:
+                        pass
+                    elif "QT_SCREEN_SCALE_FACTORS" in os.environ:
+                        pass
+                    else:
+                        QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
 
                 qt_application = QtGui.QApplication([])
                 qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))

--- a/engine.py
+++ b/engine.py
@@ -175,6 +175,10 @@ class ShellEngine(Engine):
             # start up our QApp now, if none is already running
             qt_application = None
             if not QtGui.QApplication.instance():
+                # Enable High DPI support in Qt5 (default enabled in Qt6)
+                if QtCore.qVersion()[0] == "5":
+                    QtCore.QCoreApplication.setAttribute(QtCore.Qt.AA_EnableHighDpiScaling)
+
                 qt_application = QtGui.QApplication([])
                 qt_application.setWindowIcon(QtGui.QIcon(self.icon_256))
                 self._initialize_dark_look_and_feel()


### PR DESCRIPTION
Enable the `AA_EnableHighDpiScaling` property before instantiating the _QApplication_.

Relates to:

- shotgunsoftware/tk-desktop#176
- shotgunsoftware/tk-shotgun#19
- shotgunsoftware/tk-framework-desktopstartup#126